### PR TITLE
Fix rename account link and change password/email

### DIFF
--- a/src/SFA.DAS.EAS.Web/Controllers/ServiceController.cs
+++ b/src/SFA.DAS.EAS.Web/Controllers/ServiceController.cs
@@ -2,12 +2,13 @@
 using SFA.DAS.EmployerCommitments.Domain.Interfaces;
 using SFA.DAS.EmployerCommitments.Web.Authentication;
 using SFA.DAS.EmployerCommitments.Web.Extensions;
+using SFA.DAS.EmployerCommitments.Web.Plumbing.Mvc;
 using SFA.DAS.EmployerCommitments.Web.ViewModels;
 
 namespace SFA.DAS.EmployerCommitments.Web.Controllers
 {
     [Authorize]
-    [RoutePrefix("Service")]
+    [CommitmentsRoutePrefix("Service")]
     public class ServiceController : BaseController
     {
         public ServiceController(IOwinWrapper owinWrapper, IFeatureToggle featureToggle,IMultiVariantTestingService multiVariantTestingService, ICookieStorageService<FlashMessageViewModel> flashMessage) 
@@ -22,6 +23,24 @@ namespace SFA.DAS.EmployerCommitments.Web.Controllers
         public ActionResult SignOut()
         {
             return OwinWrapper.SignOutUser(Url.ExternalUrlAction("service","signout",true));
+        }
+
+        [Authorize]
+        [HttpGet]
+        [Route("password/change")]
+        public ActionResult HandlePasswordChanged(bool userCancelled = false)
+        {
+            var url = Url.ExternalUrlAction("service", $"password/change?userCancelled={userCancelled}", true);
+            return Redirect(url);
+        }
+
+        [Authorize]
+        [HttpGet]
+        [Route("email/change")]
+        public ActionResult HandleEmailChanged(bool userCancelled = false)
+        {
+            var url = Url.ExternalUrlAction("service", $"password/change?userCancelled={userCancelled}", true);
+            return Redirect(url);
         }
     }
 }

--- a/src/SFA.DAS.EAS.Web/Views/Shared/_Layout.cshtml
+++ b/src/SFA.DAS.EAS.Web/Views/Shared/_Layout.cshtml
@@ -132,7 +132,7 @@
                                     <li><a href="@Url.ExternalUrlAction("service", "accounts",true)" role="menuitem">Your accounts</a></li>
                                     @if (string.IsNullOrWhiteSpace(ViewBag.HideNav))
                                     {     
-                                    <li><a href="@Url.ExternalUrlAction("rename",ignoreAccountId:true)" role="menuitem">Rename account</a></li>
+                                        <li><a href="@Url.ExternalUrlAction("rename")" role="menuitem">Rename account</a></li>
                                     }
                                     <li><a href="@UserLinksViewModel.ChangePasswordLink">Change your password</a></li>
                                     <li><a href="@UserLinksViewModel.ChangeEmailLink">Change your email address</a></li>


### PR DESCRIPTION
Fixed the rename account link and added the action results for the
change password and change email responses. These redirect back to EAS