### PR TITLE
Replace vpv on home page and add missing inform settting

### DIFF
--- a/src/SFA.DAS.EAS.Web/Views/EmployerCommitments/Index.cshtml
+++ b/src/SFA.DAS.EAS.Web/Views/EmployerCommitments/Index.cshtml
@@ -71,7 +71,7 @@
 @section gaDataLayer {
     <script>
         var extraProperties = {
-            'vpv': '/accounts/apprentices/inform/add-apprentice-start-page'
+            'vpv': '/accounts/apprentices/home'
         };
 
         _.assignIn(sfa.dataLayer, extraProperties);

--- a/src/SFA.DAS.EAS.Web/Views/EmployerCommitments/Inform.cshtml
+++ b/src/SFA.DAS.EAS.Web/Views/EmployerCommitments/Inform.cshtml
@@ -30,3 +30,13 @@
         <a href="@Url.Action("Index", "EmployerCommitments")" aria-label="Back to Apprentices" class="back-link">Back to Apprentices</a>
     </div>
 }
+
+@section gaDataLayer {
+    <script>
+        var extraProperties = {
+            'vpv': '/accounts/apprentices/inform/add-apprentice-start-page'
+        };
+
+        _.assignIn(sfa.dataLayer, extraProperties);
+    </script>
+}


### PR DESCRIPTION
Updated vpv values on the Apprentices Home page and added vpv that was missing from the Inform page at the start of the wizard.