### PR TITLE
DCM-925 - throwing new InvalidStateException when no apprenticeship u…

### DIFF
--- a/src/SFA.DAS.EAS.Web/Controllers/BaseController.cs
+++ b/src/SFA.DAS.EAS.Web/Controllers/BaseController.cs
@@ -7,6 +7,7 @@ using SFA.DAS.EmployerCommitments.Application;
 using SFA.DAS.EmployerCommitments.Domain.Interfaces;
 using SFA.DAS.EmployerCommitments.Domain.Models.FeatureToggle;
 using SFA.DAS.EmployerCommitments.Web.Authentication;
+using SFA.DAS.EmployerCommitments.Web.Exceptions;
 using SFA.DAS.EmployerCommitments.Web.ViewModels;
 
 namespace SFA.DAS.EmployerCommitments.Web.Controllers

--- a/src/SFA.DAS.EAS.Web/Controllers/EmployerManageApprenticesController.cs
+++ b/src/SFA.DAS.EAS.Web/Controllers/EmployerManageApprenticesController.cs
@@ -227,6 +227,7 @@ namespace SFA.DAS.EmployerCommitments.Web.Controllers
 
         [HttpGet]
         [Route("{hashedApprenticeshipId}/changes/confirm")]
+        [OutputCache(CacheProfile = "NoCache")]
         public async Task<ActionResult> ConfirmChanges(string hashedAccountId, string hashedApprenticeshipId)
         {
             var model = await _orchestrator.GetOrchestratorResponseUpdateApprenticeshipViewModelFromCookie(hashedAccountId, hashedApprenticeshipId);
@@ -330,6 +331,7 @@ namespace SFA.DAS.EmployerCommitments.Web.Controllers
 
         [HttpGet]
         [Route("{hashedApprenticeshipId}/changes/view", Name = "ViewChanges")]
+        [OutputCache(CacheProfile = "NoCache")]
         public async Task<ActionResult> ViewChanges(string hashedAccountId, string hashedApprenticeshipId)
         {
             var viewModel = await _orchestrator

--- a/src/SFA.DAS.EAS.Web/Exceptions/InvalidStateExceptionFilter.cs
+++ b/src/SFA.DAS.EAS.Web/Exceptions/InvalidStateExceptionFilter.cs
@@ -9,9 +9,8 @@ namespace SFA.DAS.EmployerCommitments.Web.Exceptions
         {
             if (filterContext.Exception.GetType() == typeof(InvalidStateException))
             {
-                LogManager.GetCurrentClassLogger().Error(filterContext.Exception, "Invalid state exception");
+                LogManager.GetCurrentClassLogger().Info(filterContext.Exception, "Invalid state exception");
 
-                // ToDo: Handle exception, Redirect or error page and User message?
                 filterContext.ExceptionHandled = true;
             }
         }

--- a/src/SFA.DAS.EAS.Web/Orchestrators/EmployerManageApprenticeshipsOrchestrator.cs
+++ b/src/SFA.DAS.EAS.Web/Orchestrators/EmployerManageApprenticeshipsOrchestrator.cs
@@ -257,6 +257,11 @@ namespace SFA.DAS.EmployerCommitments.Web.Orchestrators
 
                     var viewModel = _apprenticeshipMapper.MapFrom(data.ApprenticeshipUpdate);
 
+                    if (viewModel == null)
+                    {
+                        throw new InvalidStateException("Attempting to update an already updated Apprenticeship");
+                    }
+
                     var apprenticeship = _apprenticeshipMapper.MapToApprenticeshipDetailsViewModel(apprenticeshipResult.Apprenticeship);
                     viewModel.OriginalApprenticeship = apprenticeship;
                     viewModel.HashedAccountId = hashedAccountId;
@@ -417,8 +422,8 @@ namespace SFA.DAS.EmployerCommitments.Web.Orchestrators
         private bool CanChangeDateStepBeSkipped(ChangeStatusType changeType, GetApprenticeshipQueryResponse data)
         {
             return data.Apprenticeship.IsWaitingToStart(_currentDateTime) // Not started
-                || (data.Apprenticeship.PaymentStatus == PaymentStatus.Paused && changeType == ChangeStatusType.Resume) // Resuming 
-                || (data.Apprenticeship.PaymentStatus == PaymentStatus.Active && changeType == ChangeStatusType.Pause); // Pausing
+                || data.Apprenticeship.PaymentStatus == PaymentStatus.Paused && changeType == ChangeStatusType.Resume // Resuming 
+                || data.Apprenticeship.PaymentStatus == PaymentStatus.Active && changeType == ChangeStatusType.Pause; // Pausing
         }
 
         public async Task<ValidateWhenToApplyChangeResult> ValidateWhenToApplyChange(string hashedAccountId,

--- a/src/SFA.DAS.EAS.Web/Orchestrators/Mappers/ApprenticeshipMapper.cs
+++ b/src/SFA.DAS.EAS.Web/Orchestrators/Mappers/ApprenticeshipMapper.cs
@@ -221,19 +221,21 @@ namespace SFA.DAS.EmployerCommitments.Web.Orchestrators.Mappers
 
         public UpdateApprenticeshipViewModel MapFrom(ApprenticeshipUpdate apprenticeshipUpdate)
         {
-            return new UpdateApprenticeshipViewModel
-            {
-                Cost = NullableDecimalToString(apprenticeshipUpdate.Cost),
-                DateOfBirth = new DateTimeViewModel(apprenticeshipUpdate.DateOfBirth),
-                FirstName = apprenticeshipUpdate.FirstName,
-                LastName = apprenticeshipUpdate.LastName,
-                StartDate = new DateTimeViewModel(apprenticeshipUpdate.StartDate),
-                EndDate = new DateTimeViewModel(apprenticeshipUpdate.EndDate),
-                TrainingName = apprenticeshipUpdate.TrainingName,
-                TrainingCode = apprenticeshipUpdate.TrainingCode,
-                TrainingType = apprenticeshipUpdate.TrainingType,
-                EmployerRef = apprenticeshipUpdate.EmployerRef
-            };
+            return apprenticeshipUpdate == null
+                ? null
+                : new UpdateApprenticeshipViewModel
+                {
+                    Cost = NullableDecimalToString(apprenticeshipUpdate.Cost),
+                    DateOfBirth = new DateTimeViewModel(apprenticeshipUpdate.DateOfBirth),
+                    FirstName = apprenticeshipUpdate.FirstName,
+                    LastName = apprenticeshipUpdate.LastName,
+                    StartDate = new DateTimeViewModel(apprenticeshipUpdate.StartDate),
+                    EndDate = new DateTimeViewModel(apprenticeshipUpdate.EndDate),
+                    TrainingName = apprenticeshipUpdate.TrainingName,
+                    TrainingCode = apprenticeshipUpdate.TrainingCode,
+                    TrainingType = apprenticeshipUpdate.TrainingType,
+                    EmployerRef = apprenticeshipUpdate.EmployerRef
+                };
         }
 
         public async Task<UpdateApprenticeshipViewModel> CompareAndMapToApprenticeshipViewModel(

--- a/src/SFA.DAS.EAS.Web/Plumbing/Mvc/LogAndHandleErrorAttribute.cs
+++ b/src/SFA.DAS.EAS.Web/Plumbing/Mvc/LogAndHandleErrorAttribute.cs
@@ -9,12 +9,15 @@ namespace SFA.DAS.EmployerCommitments.Web.Plumbing.Mvc
         private static readonly ILogger Logger = LogManager.GetCurrentClassLogger();
         public override void OnException(ExceptionContext filterContext)
         {
-            var error = filterContext.Exception;
-            Logger.Error(error, "Unhandled exception - " + error.Message);
-            var ai = new TelemetryClient();
-            ai.TrackException(filterContext.Exception);
+            if (filterContext != null && !filterContext.ExceptionHandled)
+            {
+                var error = filterContext.Exception;
+                Logger.Error(error, "Unhandled exception - " + error.Message);
+                var ai = new TelemetryClient();
+                ai.TrackException(filterContext.Exception);
 
-            base.OnException(filterContext);
+                base.OnException(filterContext);
+            }
         }
     }
 }

--- a/src/SFA.DAS.EAS.Web/Views/Error/InvalidState.cshtml
+++ b/src/SFA.DAS.EAS.Web/Views/Error/InvalidState.cshtml
@@ -15,8 +15,7 @@
             </div>
             <div class="inner">
                 <p>This page is no longer available - any changes you've made up to this point have been saved.</p>
-                @*TODO*@
-                <p><a href="@Url.Action("Index", "EmployerTeam", new { hashedAccountId = @Model.HashedAccountId })">Return to the homepage</a>.</p>
+                <p><a href="@Url.Action("Index", "EmployerCommitments", new { hashedAccountId = Model.HashedAccountId })">Return to the homepage</a>.</p>
             </div>
         </div>
     </div>

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerManageApprenticeshipsOrchestratorTests/WhenGettingViewChanges.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerManageApprenticeshipsOrchestratorTests/WhenGettingViewChanges.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.Commitments.Api.Types.Apprenticeship;
+using SFA.DAS.Commitments.Api.Types.Apprenticeship.Types;
+using SFA.DAS.EmployerCommitments.Application.Queries.GetApprenticeship;
+using SFA.DAS.EmployerCommitments.Application.Queries.GetApprenticeshipUpdate;
+using SFA.DAS.EmployerCommitments.Web.Exceptions;
+
+namespace SFA.DAS.EmployerCommitments.Web.UnitTests.Orchestrators.EmployerManageApprenticeshipsOrchestratorTests
+{
+    [TestFixture]
+    public class WhenGettingViewChanges : ManageApprenticeshipsOrchestratorTestBase
+    {
+        [Test]
+        public void ThenInvalidStateExceptionOccursWhenNoViewModelReturned()
+        {
+            MockDateTime.Setup(m => m.Now).Returns(new DateTime(1998, 1, 1));
+            MockMediator.Setup(m => m.SendAsync(It.IsAny<GetApprenticeshipQueryRequest>()))
+                .ReturnsAsync(new GetApprenticeshipQueryResponse
+                {
+                    Apprenticeship =
+                        new Apprenticeship
+                        {
+                            PaymentStatus = PaymentStatus.Active,
+                            StartDate = new DateTime(1998, 1, 1)
+                        }
+                });
+            MockMediator.Setup(m => m.SendAsync(It.IsAny<GetApprenticeshipUpdateRequest>()))
+                .ReturnsAsync(new GetApprenticeshipUpdateResponse());
+
+            Assert.ThrowsAsync<InvalidStateException>(() => Orchestrator.GetViewChangesViewModel("hashedAccountId", "hashedApprenticeshipId", "UserId"));
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/Mappers/ApprenticeshipMapperBase.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/Mappers/ApprenticeshipMapperBase.cs
@@ -1,7 +1,6 @@
 ﻿using MediatR;
 
 using Moq;
-
 using SFA.DAS.EmployerCommitments.Domain.Interfaces;
 using SFA.DAS.EmployerCommitments.Web.Orchestrators.Mappers;
 using SFA.DAS.HashingService;

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/Mappers/WhenMappingApprenticeships.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/Mappers/WhenMappingApprenticeships.cs
@@ -1,0 +1,47 @@
+﻿using MediatR;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.Commitments.Api.Types.Apprenticeship;
+using SFA.DAS.EmployerCommitments.Domain.Interfaces;
+using SFA.DAS.EmployerCommitments.Web.Orchestrators.Mappers;
+using SFA.DAS.HashingService;
+using SFA.DAS.NLog.Logger;
+
+namespace SFA.DAS.EmployerCommitments.Web.UnitTests.Orchestrators.Mappers
+{
+    [TestFixture]
+    public class WhenMappingApprenticeships
+    {
+        private IApprenticeshipMapper _mapper;
+
+        [SetUp]
+        public void Setup()
+        {
+            var hashingService = new Mock<IHashingService>();
+            hashingService.Setup(x => x.DecodeValue("ABC123")).Returns(123L);
+
+            var dateTime = new Mock<ICurrentDateTime>();
+            var mediator = new Mock<IMediator>();
+            var log = new Mock<ILog>();
+            var validator = new Mock<IAcademicYearValidator>();
+
+            _mapper = new ApprenticeshipMapper(hashingService.Object, dateTime.Object, mediator.Object, log.Object, validator.Object);
+        }
+
+        [Test]
+        public void ThenMappingAnApprenticeshipUpdateShouldReturnAResult()
+        {
+            var update = new ApprenticeshipUpdate();
+
+            Assert.DoesNotThrow(() => _mapper.MapFrom(update));
+
+        }
+
+        [Test]
+        public void TheMappingAnEmptyUpdateShouldReturnNull()
+        {
+            Assert.IsNull(_mapper.MapFrom((ApprenticeshipUpdate)null));
+
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/SFA.DAS.EmployerCommitments.Web.UnitTests.csproj
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/SFA.DAS.EmployerCommitments.Web.UnitTests.csproj
@@ -177,6 +177,8 @@
     <Compile Include="Orchestrators\EmployerCommitmentOrchestrator\WhenGettingDeleteApprenticeshipConfirmation.cs" />
     <Compile Include="Orchestrators\EmployerCommitmentOrchestrator\WhenGettingFinishEditing.cs" />
     <Compile Include="Orchestrators\EmployerManageApprenticeshipsOrchestratorTests\WhenApprenticeshipsAreStoredInTheCookie.cs" />
+    <Compile Include="Orchestrators\EmployerManageApprenticeshipsOrchestratorTests\WhenGettingViewChanges.cs" />
+    <Compile Include="Orchestrators\Mappers\WhenMappingApprenticeships.cs" />
     <Compile Include="Orchestrators\Mappers\WhenMappingApprenticeshipAlertMessages.cs" />
     <Compile Include="Orchestrators\Mappers\WhenMappingApprenticeshipViewModel.cs" />
     <Compile Include="Orchestrators\Mappers\WhenMappingDataLockWithPriceHistory.cs" />


### PR DESCRIPTION
…pdate viewmodel returned. This will occur when either the user has clicked back after performing an update to an apprentice OR a race condition where another user has updated the current apprenticeship