### PR TITLE
DPP-1230 Restrict Extend Edit Ability Test Fixes

### DIFF
--- a/src/SFA.DAS.EAS.Web/Orchestrators/Mappers/ApprenticeshipMapper.cs
+++ b/src/SFA.DAS.EAS.Web/Orchestrators/Mappers/ApprenticeshipMapper.cs
@@ -118,6 +118,11 @@ namespace SFA.DAS.EmployerCommitments.Web.Orchestrators.Mappers
                                     apprenticeship.StartDate.HasValue &&
                                     _academicYearValidator.Validate(apprenticeship.StartDate.Value) == AcademicYearValidationResult.NotWithinFundingPeriod;
 
+            var isApprovedTransferAndNoSuccessfulIlrSubmission =
+                commitment.TransferSender != null
+                && commitment.TransferSender.TransferApprovalStatus == TransferApprovalStatus.Approved
+                && !apprenticeship.HasHadDataLockSuccess;
+
             return new ApprenticeshipViewModel
             {
                 HashedApprenticeshipId = _hashingService.HashValue(apprenticeship.Id),
@@ -143,7 +148,7 @@ namespace SFA.DAS.EmployerCommitments.Web.Orchestrators.Mappers
                 IsLockedForUpdate = isLockedForUpdate,
                 IsPaidForByTransfer = commitment.TransferSender != null,
                 IsInTransferRejectedCohort = commitment.TransferSender?.TransferApprovalStatus == TransferApprovalStatus.Rejected,
-                IsTransferFundedAndNoSuccessfulIlrSubmission = commitment.TransferSender != null && !apprenticeship.HasHadDataLockSuccess
+                IsApprovedTransferAndNoSuccessfulIlrSubmission = isApprovedTransferAndNoSuccessfulIlrSubmission
             };
         }
 

--- a/src/SFA.DAS.EAS.Web/Orchestrators/Mappers/ApprenticeshipMapper.cs
+++ b/src/SFA.DAS.EAS.Web/Orchestrators/Mappers/ApprenticeshipMapper.cs
@@ -119,8 +119,7 @@ namespace SFA.DAS.EmployerCommitments.Web.Orchestrators.Mappers
                                     _academicYearValidator.Validate(apprenticeship.StartDate.Value) == AcademicYearValidationResult.NotWithinFundingPeriod;
 
             var isApprovedTransferAndNoSuccessfulIlrSubmission =
-                commitment.TransferSender != null
-                && commitment.TransferSender.TransferApprovalStatus == TransferApprovalStatus.Approved
+                commitment.TransferSender?.TransferApprovalStatus == TransferApprovalStatus.Approved
                 && !apprenticeship.HasHadDataLockSuccess;
 
             return new ApprenticeshipViewModel

--- a/src/SFA.DAS.EAS.Web/ViewModels/ApprenticeshipViewModel.cs
+++ b/src/SFA.DAS.EAS.Web/ViewModels/ApprenticeshipViewModel.cs
@@ -71,7 +71,7 @@ namespace SFA.DAS.EmployerCommitments.Web.ViewModels
 
         public bool IsPaidForByTransfer { get; set; }
 
-        public bool IsTransferFundedAndNoSuccessfulIlrSubmission { get; set; }
+        public bool IsApprovedTransferAndNoSuccessfulIlrSubmission { get; set; }
 
         public string FirstNameError => GetErrorMessage(nameof(FirstName));
         public string LastNameError => GetErrorMessage(nameof(LastName));

--- a/src/SFA.DAS.EAS.Web/Views/EmployerManageApprentices/Edit.cshtml
+++ b/src/SFA.DAS.EAS.Web/Views/EmployerManageApprentices/Edit.cshtml
@@ -51,7 +51,7 @@
             @Html.Hidden("uln", Model.Data.Apprenticeship.ULN)
             @Html.Hidden("HasStarted", Model.Data.Apprenticeship.HasStarted)
             @Html.Hidden("IsLockedForUpdate", Model.Data.Apprenticeship.IsLockedForUpdate)
-            @Html.Hidden("IsTransferFundedAndNoSuccessfulIlrSubmission", Model.Data.Apprenticeship.IsTransferFundedAndNoSuccessfulIlrSubmission)
+            @Html.Hidden("IsApprovedTransferAndNoSuccessfulIlrSubmission", Model.Data.Apprenticeship.IsApprovedTransferAndNoSuccessfulIlrSubmission)
 
             @* next line deliberately left commented. uncomment to take account of editing transfers in manage your apprenticeships *@
             @*@Html.Hidden("IsPaidForByTransfer", Model.Data.Apprenticeship.IsPaidForByTransfer)*@

--- a/src/SFA.DAS.EAS.Web/Views/EmployerManageApprentices/EditStartedApprenticeship.cshtml
+++ b/src/SFA.DAS.EAS.Web/Views/EmployerManageApprentices/EditStartedApprenticeship.cshtml
@@ -68,7 +68,7 @@
         </div>
     </div>
 
-    @if (Model.Apprenticeship.IsLockedForUpdate || Model.Apprenticeship.IsTransferFundedAndNoSuccessfulIlrSubmission)
+    @if (Model.Apprenticeship.IsLockedForUpdate || Model.Apprenticeship.IsApprovedTransferAndNoSuccessfulIlrSubmission)
     {
         <div class="form-group">
             <hr />
@@ -100,7 +100,7 @@
         </div>
     }
 
-    @if (Model.Apprenticeship.IsLockedForUpdate || Model.Apprenticeship.IsTransferFundedAndNoSuccessfulIlrSubmission)
+    @if (Model.Apprenticeship.IsLockedForUpdate || Model.Apprenticeship.IsApprovedTransferAndNoSuccessfulIlrSubmission)
     {
         <div class="form-error-group form-group">
             <hr />
@@ -124,7 +124,7 @@
     }
     else
     {
-        if (!Model.Apprenticeship.IsTransferFundedAndNoSuccessfulIlrSubmission)
+        if (!Model.Apprenticeship.IsApprovedTransferAndNoSuccessfulIlrSubmission)
         {
             <div class="form-error-group form-group @(!string.IsNullOrEmpty(Model.Apprenticeship.StartDateError)
                                                       || !string.IsNullOrEmpty(Model.Apprenticeship.StartDateOverlapError)

--- a/src/SFA.DAS.EAS.Web/Views/Shared/EditApprenticeship.cshtml
+++ b/src/SFA.DAS.EAS.Web/Views/Shared/EditApprenticeship.cshtml
@@ -81,7 +81,7 @@ else
     <div class="form-group @(!string.IsNullOrEmpty(Model.Apprenticeship.TrainingCodeError) ? "error" : "")">
         <hr />
         <label class="form-label-bold" for="TrainingCode">Apprenticeship training course</label>
-        @if (Model.Apprenticeship.IsTransferFundedAndNoSuccessfulIlrSubmission)
+        @if (Model.Apprenticeship.IsApprovedTransferAndNoSuccessfulIlrSubmission)
         {
             <span id="TrainingCode">@Model.Apprenticeship.TrainingName</span>
             @Html.Hidden("TrainingCode", Model.Apprenticeship.TrainingCode)
@@ -111,7 +111,7 @@ else
 
     <span class="form-label-bold">Planned training start date</span>
 
-    @if (Model.Apprenticeship.IsTransferFundedAndNoSuccessfulIlrSubmission)
+    @if (Model.Apprenticeship.IsApprovedTransferAndNoSuccessfulIlrSubmission)
     {
         <span>@Model.Apprenticeship.StartDate.DateTime.Value.ToGdsFormatWithoutDay()</span>
 

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/Mappers/WhenMappingApprenticeshipViewModel.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/Mappers/WhenMappingApprenticeshipViewModel.cs
@@ -126,21 +126,27 @@ namespace SFA.DAS.EmployerCommitments.Web.UnitTests.Orchestrators.Mappers
             Assert.AreEqual(expectRejectionIndicated, viewModel.IsInTransferRejectedCohort);
         }
 
-        [TestCase(true, false, true)]
-        [TestCase(false, true, true)]
-        [TestCase(false, false, false)]
-        [TestCase(false, true, false)]
-        public void ThenIsTransferFundedAndNoSuccessfulIlrSubmissionShouldBeSetCorrectly(bool expected, bool dataLockSuccess, bool transferSender)
+        [TestCase(true, false, true, TransferApprovalStatus.Approved)]
+        [TestCase(false, true, true, TransferApprovalStatus.Approved)]
+        [TestCase(false, false, true, TransferApprovalStatus.Pending)]
+        [TestCase(false, true, true, TransferApprovalStatus.Pending)]
+        [TestCase(false, false, true, TransferApprovalStatus.Rejected)]
+        [TestCase(false, true, true, TransferApprovalStatus.Rejected)]
+        [TestCase(false, false, false, null)]
+        [TestCase(false, true, false, null)]
+        public void ThenIsApprovedTransferAndNoSuccessfulIlrSubmissionShouldBeSetCorrectly(bool expected, bool dataLockSuccess, bool transferSender, TransferApprovalStatus? transferApprovalStatus)
         {
             var apprenticeship = new Apprenticeship { HasHadDataLockSuccess = dataLockSuccess };
             var commitment = new CommitmentView();
 
             if (transferSender)
-                commitment.TransferSender = new TransferSender();
+            {
+                commitment.TransferSender = new TransferSender {TransferApprovalStatus = transferApprovalStatus};
+            }
 
             var viewModel = Sut.MapToApprenticeshipViewModel(apprenticeship, commitment);
 
-            Assert.AreEqual(expected, viewModel.IsTransferFundedAndNoSuccessfulIlrSubmission);
+            Assert.AreEqual(expected, viewModel.IsApprovedTransferAndNoSuccessfulIlrSubmission);
         }
     }
 }


### PR DESCRIPTION
This PR provides a fix to only lock down the start date and training fields on the edit apprenticeship page when the apprenticeship is part of a transfer funded cohort and there has been no successful ILR submission, only when the cohort has been approved by all three parties.
