### PR TITLE
Con 2229 capture redundancy when record status is waiting to start

### DIFF
--- a/src/SFA.DAS.EAS.Web/Controllers/EmployerManageApprenticesController.cs
+++ b/src/SFA.DAS.EAS.Web/Controllers/EmployerManageApprenticesController.cs
@@ -160,7 +160,15 @@ namespace SFA.DAS.EmployerCommitments.Web.Controllers
 
             var response = await _orchestrator.GetChangeStatusDateOfChangeViewModel(hashedAccountId, hashedApprenticeshipId, changeType, OwinWrapper.GetClaimValue(@"sub"));
 
-            if (response.Data.SkipStep)
+            if (response.Data.SkipToMadeRedundantQuestion)
+                return RedirectToRoute("MadeRedundant", new
+                {
+                    changeType = response.Data.ChangeStatusViewModel.ChangeType.ToString().ToLower(),
+                    whenToMakeChange = WhenToMakeChangeOptions.Immediately,
+                    dateOfChange = default(DateTime?)
+                });
+
+            if (response.Data.SkipToConfirmationPage)
                 return RedirectToRoute("StatusChangeConfirmation", new
                 {
                     changeType = response.Data.ChangeStatusViewModel.ChangeType.ToString().ToLower(),

--- a/src/SFA.DAS.EAS.Web/Orchestrators/EmployerManageApprenticeshipsOrchestrator.cs
+++ b/src/SFA.DAS.EAS.Web/Orchestrators/EmployerManageApprenticeshipsOrchestrator.cs
@@ -320,7 +320,7 @@ namespace SFA.DAS.EmployerCommitments.Web.Orchestrators
                     {
                         ApprenticeStartDate = data.Apprenticeship.StartDate.Value,
                         SkipToConfirmationPage = CanSkipToConfirmationPage(changeType, data),
-                        SkipToMadeRedundantQuestion = CanSkipToAskRedundancyQuestion(data),
+                        SkipToMadeRedundantQuestion = CanSkipToAskRedundancyQuestion(changeType, data),
                         ChangeStatusViewModel = new ChangeStatusViewModel
                         {
                             ChangeType = changeType
@@ -382,9 +382,9 @@ namespace SFA.DAS.EmployerCommitments.Web.Orchestrators
                 || data.Apprenticeship.PaymentStatus == PaymentStatus.Active && changeType == ChangeStatusType.Pause; // Pausing
         }
 
-        private bool CanSkipToAskRedundancyQuestion(GetApprenticeshipQueryResponse data)
+        private bool CanSkipToAskRedundancyQuestion(ChangeStatusType changeType, GetApprenticeshipQueryResponse data)
         {
-            return data.Apprenticeship.IsWaitingToStart(_currentDateTime);
+            return changeType == ChangeStatusType.Stop && data.Apprenticeship.IsWaitingToStart(_currentDateTime);
         }
         public async Task<ValidateWhenToApplyChangeResult> ValidateWhenToApplyChange(string hashedAccountId,
             string hashedApprenticeshipId, ChangeStatusViewModel model)

--- a/src/SFA.DAS.EAS.Web/Orchestrators/EmployerManageApprenticeshipsOrchestrator.cs
+++ b/src/SFA.DAS.EAS.Web/Orchestrators/EmployerManageApprenticeshipsOrchestrator.cs
@@ -319,7 +319,8 @@ namespace SFA.DAS.EmployerCommitments.Web.Orchestrators
                     Data = new WhenToMakeChangeViewModel
                     {
                         ApprenticeStartDate = data.Apprenticeship.StartDate.Value,
-                        SkipStep = CanChangeDateStepBeSkipped(changeType, data),
+                        SkipToConfirmationPage = CanSkipToConfirmationPage(changeType, data),
+                        SkipToMadeRedundantQuestion = CanSkipToAskRedundancyQuestion(data),
                         ChangeStatusViewModel = new ChangeStatusViewModel
                         {
                             ChangeType = changeType
@@ -375,13 +376,16 @@ namespace SFA.DAS.EmployerCommitments.Web.Orchestrators
             }, hashedAccountId, externalUserId);
         }
 
-        private bool CanChangeDateStepBeSkipped(ChangeStatusType changeType, GetApprenticeshipQueryResponse data)
+        private bool CanSkipToConfirmationPage(ChangeStatusType changeType, GetApprenticeshipQueryResponse data)
         {
-            return data.Apprenticeship.IsWaitingToStart(_currentDateTime) // Not started
-                || data.Apprenticeship.PaymentStatus == PaymentStatus.Paused && changeType == ChangeStatusType.Resume // Resuming 
+            return data.Apprenticeship.PaymentStatus == PaymentStatus.Paused && changeType == ChangeStatusType.Resume // Resuming 
                 || data.Apprenticeship.PaymentStatus == PaymentStatus.Active && changeType == ChangeStatusType.Pause; // Pausing
         }
 
+        private bool CanSkipToAskRedundancyQuestion(GetApprenticeshipQueryResponse data)
+        {
+            return data.Apprenticeship.IsWaitingToStart(_currentDateTime);
+        }
         public async Task<ValidateWhenToApplyChangeResult> ValidateWhenToApplyChange(string hashedAccountId,
             string hashedApprenticeshipId, ChangeStatusViewModel model)
         {

--- a/src/SFA.DAS.EAS.Web/ViewModels/ManageApprenticeships/WhenToMakeChangeViewModel.cs
+++ b/src/SFA.DAS.EAS.Web/ViewModels/ManageApprenticeships/WhenToMakeChangeViewModel.cs
@@ -4,7 +4,8 @@ namespace SFA.DAS.EmployerCommitments.Web.ViewModels.ManageApprenticeships
 {
     public sealed class WhenToMakeChangeViewModel
     {
-        public bool SkipStep { get; set; }
+        public bool SkipToMadeRedundantQuestion { get; set; }
+        public bool SkipToConfirmationPage { get; set; }
         public ChangeStatusViewModel ChangeStatusViewModel { get; set; }
         public DateTime ApprenticeStartDate { get; set; }
         public string ApprenticeshipULN { get; set; }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerManageApprenticeshipsOrchestratorTests/WhenUserSelectsToEditStatus.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerManageApprenticeshipsOrchestratorTests/WhenUserSelectsToEditStatus.cs
@@ -37,13 +37,14 @@ namespace SFA.DAS.EmployerCommitments.Web.UnitTests.Orchestrators.EmployerManage
 
         [TestCase(PaymentStatus.Active)]
         [TestCase(PaymentStatus.Paused)]
-        public async Task ThenShouldSkipSelectingChangeDateIfTrainingHasNotStarted(PaymentStatus paymentStatus)
+        public async Task OfAnActiveOrPausedApprenticeshipThatHasNotYetStarted_ThenTheyShouldSkipSelectingChangeDateAndMoveToMadeRedundantQuestion(PaymentStatus paymentStatus)
         {
             _testApprenticeship.PaymentStatus = paymentStatus;
 
             OrchestratorResponse<WhenToMakeChangeViewModel> response = await Orchestrator.GetChangeStatusDateOfChangeViewModel("ABC123", "CDE321", ChangeStatusType.Stop, "user123");
 
-            response.Data.SkipStep.Should().BeTrue();
+            response.Data.SkipToConfirmationPage.Should().BeFalse();
+            response.Data.SkipToMadeRedundantQuestion.Should().BeTrue();
         }
 
         [Test]
@@ -53,7 +54,7 @@ namespace SFA.DAS.EmployerCommitments.Web.UnitTests.Orchestrators.EmployerManage
 
             OrchestratorResponse<WhenToMakeChangeViewModel> response = await Orchestrator.GetChangeStatusDateOfChangeViewModel("ABC123", "CDE321", ChangeStatusType.Pause, "user123");
 
-            response.Data.SkipStep.Should().BeTrue();
+            response.Data.SkipToConfirmationPage.Should().BeTrue();
         }
 
         [Test]
@@ -63,7 +64,7 @@ namespace SFA.DAS.EmployerCommitments.Web.UnitTests.Orchestrators.EmployerManage
             _testApprenticeship.PauseDate = MockDateTime.Object.Now.AddMonths(-1);
             OrchestratorResponse<WhenToMakeChangeViewModel> response = await Orchestrator.GetChangeStatusDateOfChangeViewModel("ABC123", "CDE321", ChangeStatusType.Resume, "user123");
 
-            response.Data.SkipStep.Should().BeTrue();
+            response.Data.SkipToConfirmationPage.Should().BeTrue();
         }
        
         [Test]
@@ -74,7 +75,7 @@ namespace SFA.DAS.EmployerCommitments.Web.UnitTests.Orchestrators.EmployerManage
 
             OrchestratorResponse<WhenToMakeChangeViewModel> response = await Orchestrator.GetChangeStatusDateOfChangeViewModel("ABC123", "CDE321", ChangeStatusType.Pause, "user123");
 
-            response.Data.SkipStep.Should().BeTrue();
+            response.Data.SkipToConfirmationPage.Should().BeTrue();
         }
        
         [Test]
@@ -85,7 +86,7 @@ namespace SFA.DAS.EmployerCommitments.Web.UnitTests.Orchestrators.EmployerManage
 
             OrchestratorResponse<WhenToMakeChangeViewModel> response = await Orchestrator.GetChangeStatusDateOfChangeViewModel("ABC123", "CDE321", ChangeStatusType.Resume, "user123");
 
-            response.Data.SkipStep.Should().BeTrue();
+            response.Data.SkipToConfirmationPage.Should().BeTrue();
         }
        
         [TestCase(PaymentStatus.Active)]
@@ -97,7 +98,7 @@ namespace SFA.DAS.EmployerCommitments.Web.UnitTests.Orchestrators.EmployerManage
 
             OrchestratorResponse<WhenToMakeChangeViewModel> response = await Orchestrator.GetChangeStatusDateOfChangeViewModel("ABC123", "CDE321", ChangeStatusType.Stop, "user123");
 
-            response.Data.SkipStep.Should().BeFalse();
+            response.Data.SkipToConfirmationPage.Should().BeFalse();
         }
 
 

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerManageApprenticeshipsOrchestratorTests/WhenUserSelectsToEditStatus.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerManageApprenticeshipsOrchestratorTests/WhenUserSelectsToEditStatus.cs
@@ -48,17 +48,18 @@ namespace SFA.DAS.EmployerCommitments.Web.UnitTests.Orchestrators.EmployerManage
         }
 
         [Test]
-        public async Task ThenShouldSkipSelectingChangeDateIfPausingLiveApprenticeship()
+        public async Task ByPausingAnActiveApprenticeship_ThenShouldSkipToTheConfirmationPageAndNotBeAskedIfTheyAreBeingMadeRedundant()
         {
             _testApprenticeship.PaymentStatus = PaymentStatus.Active;
 
             OrchestratorResponse<WhenToMakeChangeViewModel> response = await Orchestrator.GetChangeStatusDateOfChangeViewModel("ABC123", "CDE321", ChangeStatusType.Pause, "user123");
 
             response.Data.SkipToConfirmationPage.Should().BeTrue();
+            response.Data.SkipToMadeRedundantQuestion.Should().BeFalse();
         }
 
         [Test]
-        public async Task ThenShouldSkipSelectingChangeDateIfResumingApprenticeship()
+        public async Task ByResumingAnApprenticeship_ThenShouldSkipToConfirmationPage()
         {
             _testApprenticeship.PaymentStatus = PaymentStatus.Paused;
             _testApprenticeship.PauseDate = MockDateTime.Object.Now.AddMonths(-1);
@@ -68,7 +69,7 @@ namespace SFA.DAS.EmployerCommitments.Web.UnitTests.Orchestrators.EmployerManage
         }
        
         [Test]
-        public async Task ThenShouldSkipSelectingChangeDateIfPausingWaitingToStartApprenticeship()
+        public async Task ThenShouldSkipToConfirmationPage_IfPausingWaitingToStartApprenticeship()
         {
             _testApprenticeship.PaymentStatus = PaymentStatus.Active;
             _testApprenticeship.StartDate = DateTime.UtcNow.AddMonths(-1); // Already started
@@ -76,6 +77,7 @@ namespace SFA.DAS.EmployerCommitments.Web.UnitTests.Orchestrators.EmployerManage
             OrchestratorResponse<WhenToMakeChangeViewModel> response = await Orchestrator.GetChangeStatusDateOfChangeViewModel("ABC123", "CDE321", ChangeStatusType.Pause, "user123");
 
             response.Data.SkipToConfirmationPage.Should().BeTrue();
+            response.Data.SkipToMadeRedundantQuestion.Should().BeFalse();
         }
        
         [Test]


### PR DESCRIPTION
I have renamed the SkipStep property as this scenario is now skipping two steps (1-Date the apprenticeship was stopped, 2-Were they made redundant). I've also added another redirect on the date page GET to move to the redundancy question if the training hasn't started yet