### PR TITLE
CON-2487 CoP link on apprentice details page

### DIFF
--- a/src/SFA.DAS.CloudService/Configuration/ServiceDefinition.Cloud.csdef
+++ b/src/SFA.DAS.CloudService/Configuration/ServiceDefinition.Cloud.csdef
@@ -38,6 +38,7 @@
       <Setting name="FeatureToggle.EmployerCommitmentsV2" />
       <Setting name="FeatureToggle.EnhancedApprovals" />
       <Setting name="FeatureToggle.EmployerManageApprenticesV2" />
+      <Setting name="FeatureToggle.ChangeOfProvider" />
     </ConfigurationSettings>
     <Endpoints>
       <InputEndpoint name="HttpsIn" protocol="https" port="443" certificate="WebSslCert" />

--- a/src/SFA.DAS.CloudService/Configuration/ServiceDefinition.Release.csdef
+++ b/src/SFA.DAS.CloudService/Configuration/ServiceDefinition.Release.csdef
@@ -38,6 +38,7 @@
       <Setting name="FeatureToggle.EmployerCommitmentsV2" />
       <Setting name="FeatureToggle.EnhancedApprovals" />
       <Setting name="FeatureToggle.EmployerManageApprenticesV2" />
+      <Setting name="FeatureToggle.ChangeOfProvider" />
     </ConfigurationSettings>
     <Endpoints>
       <InputEndpoint name="HttpsIn" protocol="https" port="443" certificate="WebSslCert" loadBalancer="das-empc-ilb"/>

--- a/src/SFA.DAS.CloudService/ServiceConfiguration.Cloud.cscfg
+++ b/src/SFA.DAS.CloudService/ServiceConfiguration.Cloud.cscfg
@@ -25,6 +25,7 @@
       <Setting name="FeatureToggle.EmployerCommitmentsV2" value="__FeatureToggle.EmployerCommitmentsV2__" />
       <Setting name="FeatureToggle.EnhancedApprovals" value="__FeatureToggle.EnhancedApprovals__" />
       <Setting name="FeatureToggle.EmployerManageApprenticesV2" value="__FeatureToggle.EmployerManageApprenticesV2__" />
+      <Setting name="FeatureToggle.ChangeOfProvider" value="__FeatureToggle.ChageOfProvider__" />
     </ConfigurationSettings>
     <Certificates>
       <Certificate name="WebSslCert" thumbprint="D4B7EBCE1013CBB10A6DD74D1A20E2C9A69107A2" thumbprintAlgorithm="sha1" />

--- a/src/SFA.DAS.CloudService/ServiceConfiguration.Cloud.cscfg
+++ b/src/SFA.DAS.CloudService/ServiceConfiguration.Cloud.cscfg
@@ -25,7 +25,7 @@
       <Setting name="FeatureToggle.EmployerCommitmentsV2" value="__FeatureToggle.EmployerCommitmentsV2__" />
       <Setting name="FeatureToggle.EnhancedApprovals" value="__FeatureToggle.EnhancedApprovals__" />
       <Setting name="FeatureToggle.EmployerManageApprenticesV2" value="__FeatureToggle.EmployerManageApprenticesV2__" />
-      <Setting name="FeatureToggle.ChangeOfProvider" value="__FeatureToggle.ChageOfProvider__" />
+      <Setting name="FeatureToggle.ChangeOfProvider" value="__FeatureToggle.ChangeOfProvider__" />
     </ConfigurationSettings>
     <Certificates>
       <Certificate name="WebSslCert" thumbprint="D4B7EBCE1013CBB10A6DD74D1A20E2C9A69107A2" thumbprintAlgorithm="sha1" />

--- a/src/SFA.DAS.CloudService/ServiceConfiguration.Local.cscfg
+++ b/src/SFA.DAS.CloudService/ServiceConfiguration.Local.cscfg
@@ -25,6 +25,7 @@
       <Setting name="FeatureToggle.EmployerCommitmentsV2" value="true" />
       <Setting name="FeatureToggle.EnhancedApprovals" value="true" />
       <Setting name="FeatureToggle.EmployerManageApprenticesV2" value="true" />
+      <Setting name="FeatureToggle.ChangeOfProvider" value="true" />
     </ConfigurationSettings>
     <Certificates>
       <Certificate name="WebSslCert" thumbprint="f4dddca9a2863480b0c9648928434f2e959e8d89" thumbprintAlgorithm="sha1" />

--- a/src/SFA.DAS.CloudService/ServiceConfiguration.MO.cscfg
+++ b/src/SFA.DAS.CloudService/ServiceConfiguration.MO.cscfg
@@ -25,6 +25,7 @@
       <Setting name="FeatureToggle.EmployerCommitmentsV2" value="__FeatureToggle.EmployerCommitmentsV2__" />
       <Setting name="FeatureToggle.EnhancedApprovals" value="__FeatureToggle.EnhancedApprovals__" />
       <Setting name="FeatureToggle.EmployerManageApprenticesV2" value="__FeatureToggle.EmployerManageApprenticesV2__" />
+      <Setting name="FeatureToggle.ChangeOfProvider" value="__FeatureToggle.ChageOfProvider__" />
     </ConfigurationSettings>
     <Certificates>
       <Certificate name="WebSslCert" thumbprint="D4B7EBCE1013CBB10A6DD74D1A20E2C9A69107A2" thumbprintAlgorithm="sha1" />

--- a/src/SFA.DAS.CloudService/ServiceConfiguration.MO.cscfg
+++ b/src/SFA.DAS.CloudService/ServiceConfiguration.MO.cscfg
@@ -25,7 +25,7 @@
       <Setting name="FeatureToggle.EmployerCommitmentsV2" value="__FeatureToggle.EmployerCommitmentsV2__" />
       <Setting name="FeatureToggle.EnhancedApprovals" value="__FeatureToggle.EnhancedApprovals__" />
       <Setting name="FeatureToggle.EmployerManageApprenticesV2" value="__FeatureToggle.EmployerManageApprenticesV2__" />
-      <Setting name="FeatureToggle.ChangeOfProvider" value="__FeatureToggle.ChageOfProvider__" />
+      <Setting name="FeatureToggle.ChangeOfProvider" value="__FeatureToggle.ChangeOfProvider__" />
     </ConfigurationSettings>
     <Certificates>
       <Certificate name="WebSslCert" thumbprint="D4B7EBCE1013CBB10A6DD74D1A20E2C9A69107A2" thumbprintAlgorithm="sha1" />

--- a/src/SFA.DAS.CloudService/ServiceConfiguration.PreProd.cscfg
+++ b/src/SFA.DAS.CloudService/ServiceConfiguration.PreProd.cscfg
@@ -25,6 +25,7 @@
       <Setting name="FeatureToggle.EmployerCommitmentsV2" value="__FeatureToggle.EmployerCommitmentsV2__" />
       <Setting name="FeatureToggle.EnhancedApprovals" value="__FeatureToggle.EnhancedApprovals__" />
       <Setting name="FeatureToggle.EmployerManageApprenticesV2" value="__FeatureToggle.EmployerManageApprenticesV2__" />
+      <Setting name="FeatureToggle.ChangeOfProvider" value="__FeatureToggle.ChageOfProvider__" />
     </ConfigurationSettings>
     <Certificates>
       <Certificate name="WebSslCert" thumbprint="D4B7EBCE1013CBB10A6DD74D1A20E2C9A69107A2" thumbprintAlgorithm="sha1" />

--- a/src/SFA.DAS.CloudService/ServiceConfiguration.PreProd.cscfg
+++ b/src/SFA.DAS.CloudService/ServiceConfiguration.PreProd.cscfg
@@ -25,7 +25,7 @@
       <Setting name="FeatureToggle.EmployerCommitmentsV2" value="__FeatureToggle.EmployerCommitmentsV2__" />
       <Setting name="FeatureToggle.EnhancedApprovals" value="__FeatureToggle.EnhancedApprovals__" />
       <Setting name="FeatureToggle.EmployerManageApprenticesV2" value="__FeatureToggle.EmployerManageApprenticesV2__" />
-      <Setting name="FeatureToggle.ChangeOfProvider" value="__FeatureToggle.ChageOfProvider__" />
+      <Setting name="FeatureToggle.ChangeOfProvider" value="__FeatureToggle.ChangeOfProvider__" />
     </ConfigurationSettings>
     <Certificates>
       <Certificate name="WebSslCert" thumbprint="D4B7EBCE1013CBB10A6DD74D1A20E2C9A69107A2" thumbprintAlgorithm="sha1" />

--- a/src/SFA.DAS.CloudService/ServiceConfiguration.Release.cscfg
+++ b/src/SFA.DAS.CloudService/ServiceConfiguration.Release.cscfg
@@ -25,6 +25,7 @@
       <Setting name="FeatureToggle.EmployerCommitmentsV2" value="__FeatureToggle.EmployerCommitmentsV2__" />
       <Setting name="FeatureToggle.EnhancedApprovals" value="__FeatureToggle.EnhancedApprovals__" />
       <Setting name="FeatureToggle.EmployerManageApprenticesV2" value="__FeatureToggle.EmployerManageApprenticesV2__" />
+      <Setting name="FeatureToggle.ChangeOfProvider" value="__FeatureToggle.ChageOfProvider__" />
     </ConfigurationSettings>
     <Certificates>
       <Certificate name="WebSslCert" thumbprint="60F4C3C90D283A45E0AE740189217D51BD163453" thumbprintAlgorithm="sha1" />

--- a/src/SFA.DAS.CloudService/ServiceConfiguration.Release.cscfg
+++ b/src/SFA.DAS.CloudService/ServiceConfiguration.Release.cscfg
@@ -25,7 +25,7 @@
       <Setting name="FeatureToggle.EmployerCommitmentsV2" value="__FeatureToggle.EmployerCommitmentsV2__" />
       <Setting name="FeatureToggle.EnhancedApprovals" value="__FeatureToggle.EnhancedApprovals__" />
       <Setting name="FeatureToggle.EmployerManageApprenticesV2" value="__FeatureToggle.EmployerManageApprenticesV2__" />
-      <Setting name="FeatureToggle.ChangeOfProvider" value="__FeatureToggle.ChageOfProvider__" />
+      <Setting name="FeatureToggle.ChangeOfProvider" value="__FeatureToggle.ChangeOfProvider__" />
     </ConfigurationSettings>
     <Certificates>
       <Certificate name="WebSslCert" thumbprint="60F4C3C90D283A45E0AE740189217D51BD163453" thumbprintAlgorithm="sha1" />

--- a/src/SFA.DAS.CloudService/ServiceDefinition.csdef
+++ b/src/SFA.DAS.CloudService/ServiceDefinition.csdef
@@ -38,6 +38,7 @@
       <Setting name="FeatureToggle.EmployerCommitmentsV2" />
       <Setting name="FeatureToggle.EnhancedApprovals" />
       <Setting name="FeatureToggle.EmployerManageApprenticesV2" />
+      <Setting name="FeatureToggle.ChangeOfProvider" />
     </ConfigurationSettings>
     <Endpoints>
       <InputEndpoint name="HttpsIn" protocol="https" port="443" certificate="WebSslCert" />

--- a/src/SFA.DAS.EAS.Web/ViewModels/ManageApprenticeships/ApprenticeshipDetailsViewModel.cs
+++ b/src/SFA.DAS.EAS.Web/ViewModels/ManageApprenticeships/ApprenticeshipDetailsViewModel.cs
@@ -62,6 +62,7 @@ namespace SFA.DAS.EmployerCommitments.Web.ViewModels.ManageApprenticeships
         public string EditApprenticeshipEndDateLink { get; set; }
 
         public bool? MadeRedundant { get; set; }
+        public string ChangeProviderLink { get; set; }
     }
 
     public enum PendingChanges

--- a/src/SFA.DAS.EAS.Web/Views/EmployerManageApprentices/Details.cshtml
+++ b/src/SFA.DAS.EAS.Web/Views/EmployerManageApprentices/Details.cshtml
@@ -149,7 +149,16 @@
                 <tr>
                     <th scope="row">Training provider</th>
                     <td>@Model.Data.ProviderName</td>
-                    <td></td>
+                    @if (Model.Data.PaymentStatus == PaymentStatus.Withdrawn && !string.IsNullOrEmpty(Model.Data.ChangeProviderLink))
+                    {
+                        <td class="link-right">
+                            <a id="changeTrainingProviderLink" href="@Model.Data.ChangeProviderLink" aria-label="Changing training provider">Change</a>
+                        </td>
+                    }
+                    else
+                    {
+                        <td></td>
+                    }
                 </tr>
                 <tr>
                     <th scope="row">Cohort reference</th>

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Domain/Models/FeatureToggles/ChangeOfProvider.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Domain/Models/FeatureToggles/ChangeOfProvider.cs
@@ -1,0 +1,9 @@
+﻿using FeatureToggle;
+
+namespace SFA.DAS.EmployerCommitments.Domain.Models.FeatureToggles
+{
+    public class ChangeOfProvider : SimpleFeatureToggle
+    {
+        
+    }
+}

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Domain/SFA.DAS.EmployerCommitments.Domain.csproj
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Domain/SFA.DAS.EmployerCommitments.Domain.csproj
@@ -313,6 +313,7 @@
     <Compile Include="Models\Apprenticeship\ChangeStatusType.cs" />
     <Compile Include="Models\Apprenticeship\FundingStatus.cs" />
     <Compile Include="Models\Apprenticeship\RecordStatus.cs" />
+    <Compile Include="Models\FeatureToggles\ChangeOfProvider.cs" />
     <Compile Include="Models\FeatureToggles\EmployerManageApprenticesV2.cs" />
     <Compile Include="Models\FeatureToggles\EnhancedApprovals.cs" />
     <Compile Include="Models\FeatureToggles\PublicSectorReporting.cs" />

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerManageApprenticeshipsOrchestratorTests/ManageApprenticeshipsOrchestratorTestBase.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerManageApprenticeshipsOrchestratorTests/ManageApprenticeshipsOrchestratorTestBase.cs
@@ -16,6 +16,8 @@ using SFA.DAS.EmployerCommitments.Web.ViewModels.ManageApprenticeships;
 using SFA.DAS.EmployerUrlHelper;
 using SFA.DAS.NLog.Logger;
 using SFA.DAS.HashingService;
+using FeatureToggle;
+using SFA.DAS.EmployerCommitments.Domain.Models.FeatureToggles;
 
 namespace SFA.DAS.EmployerCommitments.Web.UnitTests.Orchestrators.EmployerManageApprenticeshipsOrchestratorTests
 {
@@ -28,6 +30,7 @@ namespace SFA.DAS.EmployerCommitments.Web.UnitTests.Orchestrators.EmployerManage
         protected Mock<ICurrentDateTime> MockDateTime;
         protected Mock<ILinkGenerator> MockLinkGenerator;
         protected Mock<IFeatureToggleService> MockFeatureToggleService;
+        protected Mock<IFeatureToggle> MockChangeOfProviderToggle;
 
         public IValidateApprovedApprenticeship Validator;
         protected Mock<IAcademicYearDateProvider> AcademicYearDateProvider;
@@ -58,7 +61,11 @@ namespace SFA.DAS.EmployerCommitments.Web.UnitTests.Orchestrators.EmployerManage
             AcademicYearDateProvider.Setup(x => x.CurrentAcademicYearEndDate).Returns(new DateTime(2018, 7, 31));
             AcademicYearDateProvider.Setup(x => x.LastAcademicYearFundingPeriod).Returns(new DateTime(2017, 10, 19, 18, 0, 0));
 
+            MockChangeOfProviderToggle = new Mock<IFeatureToggle>();
+            MockChangeOfProviderToggle.Setup(c => c.FeatureEnabled).Returns(true);
+
             MockFeatureToggleService = new Mock<IFeatureToggleService>();
+            MockFeatureToggleService.Setup(f => f.Get<ChangeOfProvider>()).Returns(MockChangeOfProviderToggle.Object);
 
             ApprenticeshipMapper = new ApprenticeshipMapper(Mock.Of<IHashingService>(), MockDateTime.Object,
                 MockMediator.Object, Mock.Of<ILog>(), Mock.Of<IAcademicYearValidator>(),

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerManageApprenticeshipsOrchestratorTests/ManageApprenticeshipsOrchestratorTestBase.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerManageApprenticeshipsOrchestratorTests/ManageApprenticeshipsOrchestratorTestBase.cs
@@ -27,6 +27,7 @@ namespace SFA.DAS.EmployerCommitments.Web.UnitTests.Orchestrators.EmployerManage
         protected EmployerManageApprenticeshipsOrchestrator Orchestrator;
         protected Mock<ICurrentDateTime> MockDateTime;
         protected Mock<ILinkGenerator> MockLinkGenerator;
+        protected Mock<IFeatureToggleService> MockFeatureToggleService;
 
         public IValidateApprovedApprenticeship Validator;
         protected Mock<IAcademicYearDateProvider> AcademicYearDateProvider;
@@ -57,9 +58,11 @@ namespace SFA.DAS.EmployerCommitments.Web.UnitTests.Orchestrators.EmployerManage
             AcademicYearDateProvider.Setup(x => x.CurrentAcademicYearEndDate).Returns(new DateTime(2018, 7, 31));
             AcademicYearDateProvider.Setup(x => x.LastAcademicYearFundingPeriod).Returns(new DateTime(2017, 10, 19, 18, 0, 0));
 
+            MockFeatureToggleService = new Mock<IFeatureToggleService>();
+
             ApprenticeshipMapper = new ApprenticeshipMapper(Mock.Of<IHashingService>(), MockDateTime.Object,
                 MockMediator.Object, Mock.Of<ILog>(), Mock.Of<IAcademicYearValidator>(),
-                Mock.Of<IAcademicYearDateProvider>());
+                Mock.Of<IAcademicYearDateProvider>(), MockLinkGenerator.Object, MockFeatureToggleService.Object);
 
             MockHashingService = new Mock<IHashingService>();
             MockHashingService.Setup(x => x.DecodeValue("ABC123")).Returns(123L);

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerManageApprenticeshipsOrchestratorTests/WhenMappingApprenticeship.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/EmployerManageApprenticeshipsOrchestratorTests/WhenMappingApprenticeship.cs
@@ -5,10 +5,8 @@ using Moq;
 using NUnit.Framework;
 using SFA.DAS.Commitments.Api.Types.Apprenticeship;
 using SFA.DAS.Commitments.Api.Types.Apprenticeship.Types;
-using SFA.DAS.Commitments.Api.Types.DataLock.Types;
 using SFA.DAS.EmployerCommitments.Application.Queries.GetApprenticeship;
 using SFA.DAS.EmployerCommitments.Application.Queries.GetApprenticeshipUpdate;
-using SFA.DAS.EmployerCommitments.Web.UnitTests.Orchestrators.EmployerCommitmentOrchestrator;
 using SFA.DAS.EmployerCommitments.Web.ViewModels.ManageApprenticeships;
 
 namespace SFA.DAS.EmployerCommitments.Web.UnitTests.Orchestrators.EmployerManageApprenticeshipsOrchestratorTests

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/Mappers/ApprenticeshipMapperBase.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/Mappers/ApprenticeshipMapperBase.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 using SFA.DAS.Commitments.Api.Types.Apprenticeship;
 using SFA.DAS.EmployerCommitments.Application.Queries.GetApprenticeshipsByUln;
 using SFA.DAS.EmployerCommitments.Domain.Interfaces;
+using SFA.DAS.EmployerCommitments.Domain.Models.FeatureToggles;
 using SFA.DAS.EmployerCommitments.Web.Orchestrators.Mappers;
 using SFA.DAS.EmployerUrlHelper;
 using SFA.DAS.HashingService;
@@ -25,6 +26,10 @@ namespace SFA.DAS.EmployerCommitments.Web.UnitTests.Orchestrators.Mappers
         protected Mock<IFeatureToggleService> MockFeatureToggleService;
         protected Mock<ILinkGenerator> MockLinkGenerator;
         protected Mock<IFeatureToggle> MockChangeOfProviderToggle;
+
+        protected const string TestChangeOfProviderLink = "https://commitments.apprenticehips.gov.uk/apprentice/change-training-provider";
+        protected const string HashedAccountId = "HashedAccountId";
+        protected const string HashedApprenticeshipId = "HashedApprenticeshipId";
 
         [SetUp]
         public void SetUp()
@@ -54,6 +59,11 @@ namespace SFA.DAS.EmployerCommitments.Web.UnitTests.Orchestrators.Mappers
             MockLinkGenerator = new Mock<ILinkGenerator>();
             MockChangeOfProviderToggle = new Mock<IFeatureToggle>();
             MockFeatureToggleService = new Mock<IFeatureToggleService>();
+
+            MockChangeOfProviderToggle.Setup(c => c.FeatureEnabled).Returns(true);
+            MockFeatureToggleService.Setup(f => f.Get<ChangeOfProvider>()).Returns(MockChangeOfProviderToggle.Object);
+
+            MockLinkGenerator.Setup(l => l.CommitmentsV2Link(It.IsAny<string>())).Returns(TestChangeOfProviderLink);
 
             Sut = new ApprenticeshipMapper(mockHashingService.Object, MockDateTime.Object, MockMediator.Object,
                 Mock.Of<ILog>(), AcademicYearValidator.Object, AcademicYearDateProvider.Object, MockLinkGenerator.Object, MockFeatureToggleService.Object);

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/Mappers/ApprenticeshipMapperBase.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/Mappers/ApprenticeshipMapperBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using FeatureToggle;
 using MediatR;
 
 using Moq;
@@ -8,6 +9,7 @@ using SFA.DAS.Commitments.Api.Types.Apprenticeship;
 using SFA.DAS.EmployerCommitments.Application.Queries.GetApprenticeshipsByUln;
 using SFA.DAS.EmployerCommitments.Domain.Interfaces;
 using SFA.DAS.EmployerCommitments.Web.Orchestrators.Mappers;
+using SFA.DAS.EmployerUrlHelper;
 using SFA.DAS.HashingService;
 using SFA.DAS.NLog.Logger;
 
@@ -20,6 +22,9 @@ namespace SFA.DAS.EmployerCommitments.Web.UnitTests.Orchestrators.Mappers
         protected Mock<ICurrentDateTime> MockDateTime;
         protected Mock<IAcademicYearValidator> AcademicYearValidator;
         protected Mock<IAcademicYearDateProvider> AcademicYearDateProvider;
+        protected Mock<IFeatureToggleService> MockFeatureToggleService;
+        protected Mock<ILinkGenerator> MockLinkGenerator;
+        protected Mock<IFeatureToggle> MockChangeOfProviderToggle;
 
         [SetUp]
         public void SetUp()
@@ -46,8 +51,12 @@ namespace SFA.DAS.EmployerCommitments.Web.UnitTests.Orchestrators.Mappers
                     }
                 });
 
+            MockLinkGenerator = new Mock<ILinkGenerator>();
+            MockChangeOfProviderToggle = new Mock<IFeatureToggle>();
+            MockFeatureToggleService = new Mock<IFeatureToggleService>();
+
             Sut = new ApprenticeshipMapper(mockHashingService.Object, MockDateTime.Object, MockMediator.Object,
-                Mock.Of<ILog>(), AcademicYearValidator.Object, AcademicYearDateProvider.Object);
+                Mock.Of<ILog>(), AcademicYearValidator.Object, AcademicYearDateProvider.Object, MockLinkGenerator.Object, MockFeatureToggleService.Object);
         }
     }
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/Mappers/WhenMappingApprenticeships.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/Mappers/WhenMappingApprenticeships.cs
@@ -1,15 +1,11 @@
-﻿using Moq;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using SFA.DAS.Commitments.Api.Types.Apprenticeship;
-using SFA.DAS.EmployerCommitments.Domain.Models.FeatureToggles;
 
 namespace SFA.DAS.EmployerCommitments.Web.UnitTests.Orchestrators.Mappers
 {
     [TestFixture]
     public class WhenMappingApprenticeships : ApprenticeshipMapperBase
     {
-
-        private const string TestChangeOfProviderLink = "https://commitments.apprenticehips.gov.uk/apprentice/change-training-provider";
 
         [Test]
         public void ThenMappingAnApprenticeshipUpdateShouldReturnAResult()
@@ -29,10 +25,7 @@ namespace SFA.DAS.EmployerCommitments.Web.UnitTests.Orchestrators.Mappers
         public void AndChangeOfProviderFeatureToggleIsEnabled_ThenChangeOfProviderLinkIsSet()
         {
             MockChangeOfProviderToggle.Setup(c => c.FeatureEnabled).Returns(true);
-            MockFeatureToggleService.Setup(f => f.Get<ChangeOfProvider>()).Returns(MockChangeOfProviderToggle.Object);
-
-            MockLinkGenerator.Setup(l => l.CommitmentsV2Link(It.IsAny<string>())).Returns(TestChangeOfProviderLink);
-
+         
             var result = Sut.MapToApprenticeshipDetailsViewModel(new Apprenticeship());
 
             Assert.AreEqual(TestChangeOfProviderLink, result.ChangeProviderLink);
@@ -42,10 +35,7 @@ namespace SFA.DAS.EmployerCommitments.Web.UnitTests.Orchestrators.Mappers
         public void AndChangeOfProviderFeatureToggleIsDisabled_ThenChangeOfProviderLinkIsSetToEmpty()
         {
             MockChangeOfProviderToggle.Setup(c => c.FeatureEnabled).Returns(false);
-            MockFeatureToggleService.Setup(f => f.Get<ChangeOfProvider>()).Returns(MockChangeOfProviderToggle.Object);
-
-            MockLinkGenerator.Setup(l => l.CommitmentsV2Link(It.IsAny<string>())).Returns(TestChangeOfProviderLink);
-
+            
             var result = Sut.MapToApprenticeshipDetailsViewModel(new Apprenticeship());
 
             Assert.AreEqual(string.Empty, result.ChangeProviderLink);

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/Mappers/WhenMappingApprenticeships.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/Mappers/WhenMappingApprenticeships.cs
@@ -1,48 +1,54 @@
-﻿using MediatR;
-using Moq;
+﻿using Moq;
 using NUnit.Framework;
 using SFA.DAS.Commitments.Api.Types.Apprenticeship;
-using SFA.DAS.EmployerCommitments.Domain.Interfaces;
-using SFA.DAS.EmployerCommitments.Web.Orchestrators.Mappers;
-using SFA.DAS.HashingService;
-using SFA.DAS.NLog.Logger;
+using SFA.DAS.EmployerCommitments.Domain.Models.FeatureToggles;
 
 namespace SFA.DAS.EmployerCommitments.Web.UnitTests.Orchestrators.Mappers
 {
     [TestFixture]
-    public class WhenMappingApprenticeships
+    public class WhenMappingApprenticeships : ApprenticeshipMapperBase
     {
-        private IApprenticeshipMapper _mapper;
 
-        [SetUp]
-        public void Setup()
-        {
-            var hashingService = new Mock<IHashingService>();
-            hashingService.Setup(x => x.DecodeValue("ABC123")).Returns(123L);
-
-            var dateTime = new Mock<ICurrentDateTime>();
-            var mediator = new Mock<IMediator>();
-            var log = new Mock<ILog>();
-            var validator = new Mock<IAcademicYearValidator>();
-
-            _mapper = new ApprenticeshipMapper(hashingService.Object, dateTime.Object, mediator.Object, log.Object,
-                validator.Object, Mock.Of<IAcademicYearDateProvider>());
-        }
+        private const string TestChangeOfProviderLink = "https://commitments.apprenticehips.gov.uk/apprentice/change-training-provider";
 
         [Test]
         public void ThenMappingAnApprenticeshipUpdateShouldReturnAResult()
         {
             var update = new ApprenticeshipUpdate();
 
-            Assert.DoesNotThrow(() => _mapper.MapFrom(update));
-
+            Assert.DoesNotThrow(() => Sut.MapFrom(update));
         }
 
         [Test]
         public void TheMappingAnEmptyUpdateShouldReturnNull()
         {
-            Assert.IsNull(_mapper.MapFrom((ApprenticeshipUpdate)null));
+            Assert.IsNull(Sut.MapFrom((ApprenticeshipUpdate)null));
+        }
 
+        [Test]
+        public void AndChangeOfProviderFeatureToggleIsEnabled_ThenChangeOfProviderLinkIsSet()
+        {
+            MockChangeOfProviderToggle.Setup(c => c.FeatureEnabled).Returns(true);
+            MockFeatureToggleService.Setup(f => f.Get<ChangeOfProvider>()).Returns(MockChangeOfProviderToggle.Object);
+
+            MockLinkGenerator.Setup(l => l.CommitmentsV2Link(It.IsAny<string>())).Returns(TestChangeOfProviderLink);
+
+            var result = Sut.MapToApprenticeshipDetailsViewModel(new Apprenticeship());
+
+            Assert.AreEqual(TestChangeOfProviderLink, result.ChangeProviderLink);
+        }
+
+        [Test]
+        public void AndChangeOfProviderFeatureToggleIsDisabled_ThenChangeOfProviderLinkIsSetToEmpty()
+        {
+            MockChangeOfProviderToggle.Setup(c => c.FeatureEnabled).Returns(false);
+            MockFeatureToggleService.Setup(f => f.Get<ChangeOfProvider>()).Returns(MockChangeOfProviderToggle.Object);
+
+            MockLinkGenerator.Setup(l => l.CommitmentsV2Link(It.IsAny<string>())).Returns(TestChangeOfProviderLink);
+
+            var result = Sut.MapToApprenticeshipDetailsViewModel(new Apprenticeship());
+
+            Assert.AreEqual(string.Empty, result.ChangeProviderLink);
         }
     }
 }

--- a/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/Mappers/WhenMappingEditApprenticeshipStopDateViewModel.cs
+++ b/src/SFA.DAS.EmployerApprenticeshipsService.Web.UnitTests/Orchestrators/Mappers/WhenMappingEditApprenticeshipStopDateViewModel.cs
@@ -30,7 +30,7 @@ namespace SFA.DAS.EmployerCommitments.Web.UnitTests.Orchestrators.Mappers
             AcademicYearDateProvider.Setup(x => x.CurrentAcademicYearStartDate).Returns(academicYearStartDate);
 
             Sut = new ApprenticeshipMapper(Mock.Of<IHashingService>(), MockDateTime.Object, MockMediator.Object,
-                Mock.Of<ILog>(), AcademicYearValidator.Object, AcademicYearDateProvider.Object);
+                Mock.Of<ILog>(), AcademicYearValidator.Object, AcademicYearDateProvider.Object, MockLinkGenerator.Object, MockFeatureToggleService.Object);
 
             //Act
             var result = Sut.MapToEditApprenticeshipStopDateViewModel(apprenticeship);
@@ -56,7 +56,7 @@ namespace SFA.DAS.EmployerCommitments.Web.UnitTests.Orchestrators.Mappers
             AcademicYearDateProvider.Setup(x => x.CurrentAcademicYearStartDate).Returns(academicYearStartDate);
 
             Sut = new ApprenticeshipMapper(Mock.Of<IHashingService>(), MockDateTime.Object, MockMediator.Object,
-                Mock.Of<ILog>(), AcademicYearValidator.Object, AcademicYearDateProvider.Object);
+                Mock.Of<ILog>(), AcademicYearValidator.Object, AcademicYearDateProvider.Object, MockLinkGenerator.Object, MockFeatureToggleService.Object);
 
             //Act
             var result = Sut.MapToEditApprenticeshipStopDateViewModel(apprenticeship);


### PR DESCRIPTION
This adds a change training provider link to the details page if the apprentices training has been stopped.

I've set the change link in the ApprenticeDetailViewModelMapper but behind a feature toggle. Then in the view we're only showing the link if the status is stopped and it has a value, this way it is easy to change when the change link will be used for other statuses or when the feature toggle is removed.